### PR TITLE
Occasional bad include path

### DIFF
--- a/quench/src/Fields.cc
+++ b/quench/src/Fields.cc
@@ -35,7 +35,7 @@
 
 #include "src/Geometry.h"
 
-#include "saber/src/saber/interpolation/AtlasInterpWrapper.h"
+#include "saber/interpolation/AtlasInterpWrapper.h"
 
 #define ERR(e) {ABORT(nc_strerror(e));}
 


### PR DESCRIPTION
This is a small fix for an include path. The current code fails to compile if `saber` is not cloned under a directory named `saber`. This matters when attempting to build with Spack, as it clones the repository into `spack-src`.

@climbfuji By any chance, would you be interested in incorporating recipes to build the jedi components into spack-stack?